### PR TITLE
Update vk.rb

### DIFF
--- a/lib/bank_link/mac/vk.rb
+++ b/lib/bank_link/mac/vk.rb
@@ -39,7 +39,7 @@ module BankLink
 
       def request_data version, type=:request
         keys(version, type).collect { |key_name|
-          field_for data[key_name].to_s unless data[key_name].nil?
+          field_for data[key_name].to_s if !data[key_name].nil? && data[key_name] != ''
         }.flatten.join
       end
     end


### PR DESCRIPTION
Bank response may include empty params. So my previous fix broke down response check. Now I check if param is not nil and not empty string.
